### PR TITLE
Improve readability on wide displays by limiting line length

### DIFF
--- a/sass/juice.scss
+++ b/sass/juice.scss
@@ -35,9 +35,14 @@ header {
   background-color: var(--primary-color);
   color: black;
   padding: 20px 50px;
+}
+
+.header-content {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .logo {
@@ -86,6 +91,9 @@ header {
 main {
   display: flex;
   padding: 50px 100px;
+  // Improve readability on wide displays by limiting line length.
+  max-width: 1200px;
+  margin: 0 auto;
 
   .toc {
     max-width: 260px;
@@ -148,6 +156,9 @@ footer {
 @media screen and (max-width: 768px) {
   header {
     padding: 10px 30px;
+  }
+
+  .header-content {
     flex-direction: column;
     align-items: center;
     justify-content: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,9 @@
 <body>
     {% block header %}
     <header class="box-shadow">
-        {{ macros::render_header() }}
+        <div class="header-content">
+            {{ macros::render_header() }}
+        </div>
     </header>
     {% endblock header %}
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -5,7 +5,9 @@
 
 {% block header %}
 <header class="box-shadow">
-    {{ macros::render_header() }}
+    <div class="header-content">
+        {{ macros::render_header() }}
+    </div>
 </header>
 {% endblock header %}
 


### PR DESCRIPTION
## Preview

Browser window is maximized on a 2560×1440 monitor:

### Before

![image](https://user-images.githubusercontent.com/180032/93722243-aa0e8a80-fb95-11ea-8799-0226818fcd99.png)

### After

![image](https://user-images.githubusercontent.com/180032/93769799-a58cb500-fc1b-11ea-9aba-14a652fd30fd.png)
